### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
     directory: "/"  # Location of package manifests
     commit-message:
       prefix: "[dependabot] Chore:"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "[dependabot] Chore:"
+    open-pull-requests-limit: 3
     schedule:
       interval: "weekly"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: "Publish documentation"
         if: success()
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
       ### SIGNING ###
 
       - name: "Sign packages with Sigstore"
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v2
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -62,7 +62,7 @@ jobs:
       ### SIGNING ###
 
       - name: "Sign packages with Sigstore"
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v2
 
         with:
           inputs: >-


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit